### PR TITLE
Remove non-existing function call

### DIFF
--- a/src/TestTime.php
+++ b/src/TestTime.php
@@ -48,7 +48,7 @@ class TestTime
 {
     public static function freeze(Carbon $carbon = null): Carbon
     {
-        $frozenTime = $carbon ?? now();
+        $frozenTime = $carbon ?? Carbon::now();
 
         Carbon::setTestNow($frozenTime);
 


### PR DESCRIPTION
We'll use `Carbon::now()` instead of Laravel's `now()` helper function. This makes sure the package can also be used outside of a Laravel context.