### PR TITLE
Add freezeAtSecond method

### DIFF
--- a/src/TestTime.php
+++ b/src/TestTime.php
@@ -105,6 +105,13 @@ class TestTime
         return $frozenTime;
     }
 
+    public static function freezeAtSecond(): Carbon
+    {
+        $frozenTime = static::getCarbon(func_get_args())->startOfSecond();
+
+        return static::freeze($frozenTime);
+    }
+
     public function __call($name, $arguments)
     {
         return $this->__callStatic($name, $arguments);

--- a/tests/TestTimeTest.php
+++ b/tests/TestTimeTest.php
@@ -42,4 +42,12 @@ class TestTimeTest extends TestCase
 
         $this->assertEquals('1979-09-22', Carbon::now()->format('Y-m-d'));
     }
+
+    /** @test */
+    public function it_can_freeze_the_current_time_at_the_start_of_the_second()
+    {
+        TestTime::freezeAtSecond('Y-m-d H:i:s.u', '2019-01-02 03:44:55.667788');
+
+        $this->assertEquals('2019-01-02 03:44:55.000000', (new Carbon)->format('Y-m-d H:i:s.u'));
+    }
 }


### PR DESCRIPTION
Hi there! Firstly, thanks for the package, it has really helped clean up my tests when working with time-based logic 👌 

I'm hitting an issue atm in a Laravel project where model timestamps that are saved via Eloquent don't perfectly match the frozen Carbon instance, they are a few microseconds off. This is due to the fact that `TestTime::freeze()` will freeze time including microseconds (as expected) but the model fetched from the DB will be rounded to the start of the second.

Quick example:
```php
TestTime::freeze();

$user = factory(User::class)->create(['last_online_at' => null]);

$user->update(['last_online_at' => Carbon::now()]);

$this->assertEquals(
    $user->fresh()->last_online_at, 
    Carbon::now()
);
```

Failure:
```bash
Failed asserting that two DateTime objects are equal.
--- Expected
+++ Actual
@@ @@
-2020-02-23T16:39:55.000000+0200
+2020-02-23T16:39:55.787506+0200
```

I found there were 3 ways to get around this issue:

1) Assert using `startOfSecond()` method:

```php
TestTime::freeze();

// ...

$this->assertEquals(
    $user->fresh()->last_online_at, 
    Carbon::now()->startOfSecond()
);
```

2) Assert using the `timestamp` property:

```php
TestTime::freeze();

// ...

$this->assertEquals(
    $user->fresh()->last_online_at->timestamp, 
    Carbon::now()->timestamp
);
```

3) Freeze time using `startOfSecond()` on Carbon instance:

```php
TestTime::freeze(Carbon::now()->startOfSecond());

// ...

$this->assertEquals(
    $user->fresh()->last_online_at,
    Carbon::now()
);
```


While all of these solutions got the tests back to green, I'm not a huge fan of the way it looks/reads. I felt solution 3 was the cleanest as it allowed me to write the assertions the way I expected, however I still felt it could be cleaner without having to pass the Carbon instance into the freeze method. 

This PR adds a convenience method to freeze time at the start of the second:

```php
TestTime::freezeAtSecond();

// ...

$this->assertEquals(
    $user->fresh()->last_online_at, 
    Carbon::now()
);
```

Thanks for your consideration and let me know if you have any feedback!