### PR TITLE
Add PHP 8.2 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.0, 7.4, 7.3]
+        php: [8.2, 8.1, 8.0, 7.4, 7.3]
         carbon: [2.54]
         dependency-version: [prefer-lowest, prefer-stable]
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.2, 8.1, 8.0, 7.4, 7.3]
-        carbon: [2.54]
+        carbon: [^2.63]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.dependency-version }}

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "nesbot/carbon": "^2.54"
+        "nesbot/carbon": "^2.63"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.10"


### PR DESCRIPTION
# Summary

This PR adds PHP 8.2 to the tests workflow.

It also bumps the required minimum version for `nesbot/carbon`.

_id:php82-support/v1_